### PR TITLE
define install function so make install works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,3 +82,7 @@ EXTERNALPROJECT_ADD_STEPDEPENDENCIES(scr build spath)
 EXTERNALPROJECT_ADD_STEPDEPENDENCIES(scr build er)
 EXTERNALPROJECT_ADD_STEPDEPENDENCIES(scr build dtcmp)
 SET(WITH_SCR_PREFIX ${CMAKE_INSTALL_PREFIX}/scr CACHE PATH "")
+
+# some projects require a "make install" command to work,
+# so define at least a basic INSTALL function
+INSTALL(FILE NOTICE DESTINATION share/scr)


### PR DESCRIPTION
Adding hack described in https://github.com/LLNL/scr-top/issues/5 so that a "make install" works.