### PR TITLE
fix: change FILE to FILES in INSTALL step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,4 +85,4 @@ SET(WITH_SCR_PREFIX ${CMAKE_INSTALL_PREFIX}/scr CACHE PATH "")
 
 # some projects require a "make install" command to work,
 # so define at least a basic INSTALL function
-INSTALL(FILE NOTICE DESTINATION share/scr)
+INSTALL(FILES NOTICE DESTINATION share/scr)

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ $(COMPONENTS):
 	exit;\
 	fi
 	@echo "Unpacking $@"
-	@mkdir $@
-	@tar -xzf archive/$@-*.tar.gz -C $@
+	@tar -xzf archive/$@-*.tar.gz
 
 .PHONY: build
 

--- a/git-all
+++ b/git-all
@@ -62,7 +62,7 @@ if [ $1 == "archive" ]; then
         if [ $PRINT_NAME ]; then
             echo "Archiving $i version $TAG"
         fi
-        git archive --format=tar --prefix=$i $TAG | gzip > $i-$TAG.tar.gz 2> /dev/null
+        git archive --format=tar --prefix=$i/ $TAG | gzip > $i-$TAG.tar.gz 2> /dev/null
         mv $i-$TAG.tar.gz ../$ARCH_DIR
         ARCH_LIST+="$ARCH_DIR/$i-$TAG.tar.gz "
 	cd ..
@@ -83,7 +83,7 @@ if [ $1 == "packlite" ]; then
             echo "Packing up $i"
         fi
         cd $i
-        git archive --format=tar HEAD | gzip > $i-lite.tar.gz
+        git archive --format=tar --prefix=$i/ HEAD | gzip > $i-lite.tar.gz
         mv $i-lite.tar.gz ../$ARCH_DIR
         ARCH_LIST+="$ARCH_DIR/$i-lite.tar.gz "
 	cd ..

--- a/git-all
+++ b/git-all
@@ -33,7 +33,6 @@ COMPONENTS="kvtree   \
 ORGS="ecp-veloc/kvtree   \
      ecp-veloc/axl      \
      ecp-veloc/spath    \
-     ecp-veloc/filo     \
      ecp-veloc/shuffile \
      ecp-veloc/redset   \
      ecp-veloc/er       \


### PR DESCRIPTION
This fixes a typo I have in INSTALL, and it updates git-all to skip filo.